### PR TITLE
find ompl package as a normal package, not a catkin package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,9 +6,9 @@ if(NOT CMAKE_CONFIGURATION_TYPES AND NOT CMAKE_BUILD_TYPE)
   set(CMAKE_BUILD_TYPE Release)
 endif()
 
+find_package(ompl)
 find_package(Boost REQUIRED system filesystem date_time thread serialization)
 find_package(catkin REQUIRED COMPONENTS
-  ompl
   moveit_core
   moveit_ros_planning
   moveit_msgs
@@ -28,7 +28,6 @@ catkin_package(
   INCLUDE_DIRS
     ompl_interface/include
   CATKIN_DEPENDS
-    ompl
     moveit_core
     moveit_ros_planning
     moveit_msgs
@@ -38,6 +37,8 @@ catkin_package(
     tf
     dynamic_reconfigure
     eigen_conversions
+  DEPENDS
+    ompl
 )
 
 link_directories(${Boost_LIBRARY_DIRS})


### PR DESCRIPTION
In this pull request, `ompl` is found as a normal package, not a catkin package.

With this change, I was able to build `moveit_ompl_planning_interface` package.

For your information:
https://answers.ros.org/question/154101/problem-with-catkin-depends/?answer=154916#post-id-154916